### PR TITLE
pytest-doctestplus 1.3.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytest-doctestplus" %}
-{% set version = "0.11.1" %}
+{% set version = "1.3.0" %}
 {% set git_url = "https://github.com/astropy/pytest-doctestplus" %}
 
 package:
@@ -8,8 +8,8 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b7a0aeb79b85ee81a3c72c49019b4bfeb57fa920abaa6c17ba8be3be9c5290f1
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: 709ad23ea98da9a835ace0a4365c85371c376e000f2860f30de6df3a6f00728a
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "pytest-doctestplus" %}
 {% set version = "1.3.0" %}
-{% set git_url = "https://github.com/astropy/pytest-doctestplus" %}
 
 package:
   name: {{ name|lower }}
@@ -38,7 +37,7 @@ test:
     - pip check
 
 about:
-  home: {{ git_url }}
+  home: https://github.com/astropy/pytest-doctestplus
   license_family: BSD
   license: BSD-3-Clause
   license_file: LICENSE.rst
@@ -46,8 +45,8 @@ about:
   description: |
     This package contains a plugin for the pytest framework that provides
     advanced doctest support and enables the testing of reStructuredText files.
-  doc_url: {{ git_url }}
-  dev_url: {{ git_url }}
+  doc_url: https://github.com/astropy/pytest-doctestplus
+  dev_url: https://github.com/astropy/pytest-doctestplus
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,14 +19,15 @@ requirements:
   host:
     - python
     - pip
-    - setuptools >=30.3.0
+    - setuptools
     - setuptools_scm
     - wheel
   run:
-    - python >=3.7
+    - python
     - pytest >=4.6
     - setuptools >=30.3.0
-    - packaging >=17.0
+    - sphinx
+
 test:
   imports:
     - pytest_doctestplus

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,7 @@ requirements:
   run:
     - python
     - pytest >=4.6
-    - setuptools >=30.3.0
-    - sphinx
+    - packaging >=17.0
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ test:
     - numpy
   commands:
     - pip check
-    - pytest tests -vv -k "not(test_remote_data_url or test_remote_data_float_cmp or test_remote_data_ignore_whitespace or test_remote_data_ellipsis or test_remote_data_requires or test_remote_data_ignore_warnings)"
+    - pytest tests -vv -k "not(test_remote_data_url or test_remote_data_float_cmp or test_remote_data_ignore_whitespace or test_remote_data_ellipsis or test_remote_data_requires or test_remote_data_ignore_warnings or test_ufunc or test_generate_diff_basic or test_generate_diff_multiline)"
 
 about:
   home: https://github.com/astropy/pytest-doctestplus

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 709ad23ea98da9a835ace0a4365c85371c376e000f2860f30de6df3a6f00728a
 
 build:
-  noarch: python
+  skip: True  # [py<38]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,13 +29,16 @@ requirements:
     - sphinx
 
 test:
+  source_files:
+    - tests/
   imports:
     - pytest_doctestplus
   requires:
     - pip
-    - python <3.10
+    - pytest
   commands:
     - pip check
+    - pytest tests -vv
 
 about:
   home: https://github.com/astropy/pytest-doctestplus

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,9 +36,10 @@ test:
   requires:
     - pip
     - pytest
+    - numpy
   commands:
     - pip check
-    - pytest tests -vv
+    - pytest tests -vv -k "not(test_remote_data_url or test_remote_data_float_cmp or test_remote_data_ignore_whitespace or test_remote_data_ellipsis or test_remote_data_requires or test_remote_data_ignore_warnings)"
 
 about:
   home: https://github.com/astropy/pytest-doctestplus


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6875](https://anaconda.atlassian.net/browse/PKG-6875)
- [Upstream repository](https://github.com/scientific-python/pytest-doctestplus/tree/v1.3.0)
- [Upstream changelog/diff](https://github.com/scientific-python/pytest-doctestplus/blob/v1.3.0/CHANGES.rst)
- Relevant dependency PRs:
  - dependency for `pytest-astropy`

### Explanation of changes:

- Update version and sha
- Recipe cleanup
- Remove noarch
- Update dependencies
- Add upstream tests
- Build for python 3.13
- Linter fixes


[PKG-6875]: https://anaconda.atlassian.net/browse/PKG-6875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ