### PR TITLE
pytest-doctestplus 1.7.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
 {% set name = "pytest-doctestplus" %}
-{% set version = "1.6.0" %}
+{% set version = "1.7.1" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: f893d68370d19b418d58da0047d36a4feedac7ed28bc236858f484e994f1ac66
+  sha256: 64ae16dbda66c3db775ef596828d8d7adda09c6f34dd85099c119e4ff8cfe5b6
 
 build:
   number: 0
-  skip: true  # [py<39]
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -23,17 +23,25 @@ requirements:
     - wheel
   run:
     - python
-    - pytest >=4.6
+    - pytest >=7.0
     - packaging >=17.0
 
-{% set deselect_tests = "" %}
-{% set deselect_tests = deselect_tests + " --deselect=tests/test_doctestplus.py::test_remote_data_all" %}
+{% set deselect_tests = " --deselect=tests/test_doctestplus.py::test_remote_data_all" %}
 {% set deselect_tests = deselect_tests + " --deselect=tests/test_doctestplus.py::test_remote_data_url" %}
 {% set deselect_tests = deselect_tests + " --deselect=tests/test_doctestplus.py::test_remote_data_float_cmp" %}
 {% set deselect_tests = deselect_tests + " --deselect=tests/test_doctestplus.py::test_remote_data_ignore_whitespace" %}
 {% set deselect_tests = deselect_tests + " --deselect=tests/test_doctestplus.py::test_remote_data_ellipsis" %}
 {% set deselect_tests = deselect_tests + " --deselect=tests/test_doctestplus.py::test_remote_data_requires" %}
 {% set deselect_tests = deselect_tests + " --deselect=tests/test_doctestplus.py::test_remote_data_ignore_warnings" %}
+{% set deselect_tests = deselect_tests + " --deselect=tests/test_encoding.py::test_legacy_diff" %}  # [win]
+{% set deselect_tests = deselect_tests + " --deselect=tests/test_encoding.py::test_basic_file_encoding_diff" %}  # [win]
+{% set deselect_tests = deselect_tests + " --deselect=tests/test_doctestplus.py::test_generate_diff_basic" %}  # [win]
+{% set deselect_tests = deselect_tests + " --deselect=tests/test_doctestplus.py::test_generate_diff_multiline" %}  # [win]
+
+# AttributeError, broken by https://github.com/python/cpython/pull/115440
+{% set deselect_tests = deselect_tests + " --deselect=tests/test_doctestplus.py::test_ufunc" %}  # [py==311]
+
+
 
 test:
   source_files:
@@ -42,9 +50,12 @@ test:
     - pytest_doctestplus
   requires:
     - pip
-    - pytest
     - setuptools >=30.3.0
+    - pytest-remotedata >=0.3.2
     - numpy
+    - sphinx
+    - pytest >=7.0
+    - git
   commands:
     - pip check
     - pytest -vv tests {{ deselect_tests }}


### PR DESCRIPTION
- Jira: https://anaconda.atlassian.net/browse/PKG-16888
- Dev URL (v1.7.1): https://github.com/scientific-python/pytest-doctestplus/tree/v1.7.1
- conda-forge recipe: https://github.com/conda-forge/pytest-doctestplus-feedstock 
- PyPI: https://pypi.org/project/pytest-doctestplus/1.7.1
- PyPI Inspector: https://inspector.pypi.io/project/pytest-doctestplus/1.7.1

Bump pytest-doctestplus  1.6.0 → 1.7.1